### PR TITLE
Revert "Get full permalink from server side. It was being truncated clie...

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -72,7 +72,7 @@
 			experiment = {};
 			post_id = $( '#post_ID' ).val();
 			experiment.description = 'Wordpress [' + post_id + ']: ' + $( '#title' ).val();
-			experiment.edit_url = $( '#optimizely_experiment_url' ).val();
+			experiment.edit_url = $( '#sample-permalink' ).text();
 			var loc = document.createElement( 'a' );
 			loc.href = experiment.edit_url;
 			var urlTargetdomain = loc.hostname;
@@ -132,7 +132,7 @@
 			var goal = {
 				goal_type: 3, // pageview goal
 				title: 'Views to page',
-				urls: [ $( '#optimizely_experiment_url' ).val() ],
+				urls: [ $( '#sample-permalink' ).text() ],
 				url_match_types: [4], // substring
 				addable: false, // don't clog up the goal list
 				experiment_ids: [ experiment.id ]

--- a/edit.php
+++ b/edit.php
@@ -7,18 +7,6 @@
  */
 
 /**
- * Return the full permalink of the current post.
- * @return string
- */
-function get_full_permalink() {
-	$permalinkArray = get_sample_permalink( $post->ID );
-	$permalinkTemplate = array_values( $permalinkArray )[0];
-	$permalinkSlug = array_values( $permalinkArray )[1];
-	
-	return str_replace( '%postname%', $permalinkSlug, $permalinkTemplate );
-}
-
-/**
  * Add the meta box for title variations.
  */
 function optimizely_title_variations_add() {
@@ -88,7 +76,6 @@ function optimizely_title_variations_render( $post ) {
 	<input type="hidden" id="optimizely_project_id" value="<?php echo esc_attr( get_option('optimizely_project_id') ) ?>" />
 	<input type="hidden" id="optimizely_experiment_id" name="optimizely_experiment_id" value="<?php echo esc_attr( get_post_meta( $post->ID, 'optimizely_experiment_id', true ) ) ?>" />
 	<input type="hidden" id="optimizely_experiment_status" name="optimizely_experiment_status" value="<?php echo esc_attr( get_post_meta( $post->ID, 'optimizely_experiment_status', true ) ) ?>" />
-	<input type="hidden" id="optimizely_experiment_url" name="optimizely_experiment_url" value="<?php echo get_full_permalink() ?>" />
 	<textarea id="optimizely_variation_template" style="display: none"><?php echo esc_attr( get_option( 'optimizely_variation_template' ) ) ?></textarea>
 	<?php
 }


### PR DESCRIPTION
Reverts optimizely/wordpress-plugin#7

This will not work because the if a user does not create the post first the URL in the database is something like http://localhost:8081/wordpress/?p=33 instead of the SEO friendly version. However there is a span with an ID "editable-post-name-full" that coudl be used. Try to rework it with this in mind. IF you need any help let me know